### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-runner-report.yml
+++ b/.github/workflows/generate-runner-report.yml
@@ -3,6 +3,10 @@ name: Generate Runner Usage Report
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   analyze-runners:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MVSHoneywellOrg/org-nuget-packages-consume/security/code-scanning/3](https://github.com/MVSHoneywellOrg/org-nuget-packages-consume/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. In this case:
- `contents: read` is needed to read files from the repository.
- `actions: write` is required to upload the artifact.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`analyze-runners`) to limit its scope. Adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
