### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/runnergrp.yml
+++ b/.github/workflows/runnergrp.yml
@@ -1,4 +1,6 @@
 name: Build on MVS Windows Runner
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MVSHoneywellOrg/org-nuget-packages-consume/security/code-scanning/2](https://github.com/MVSHoneywellOrg/org-nuget-packages-consume/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow involves checking out code and running build/test commands, it only needs `contents: read` permission. This ensures that the workflow cannot perform any unintended write operations.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
